### PR TITLE
Vanilla JS - Load event

### DIFF
--- a/assets/js/overlay_showAfterScroll.js
+++ b/assets/js/overlay_showAfterScroll.js
@@ -6,7 +6,7 @@
  * @copyright Erdmann & Freunde
  */
 
-jQuery(document).ready(function($) {
+window.addEventListener("load", function(e) { 
   /**
     * Funktionen für Cookies setzen, auslesen und löschen
     * Source: http://www.quirksmode.org/js/cookies.html#script

--- a/assets/js/overlay_showAfterTime.js
+++ b/assets/js/overlay_showAfterTime.js
@@ -6,7 +6,7 @@
  * @copyright Erdmann & Freunde
  */
 
-jQuery(document).ready(function($) {
+window.addEventListener("load", function(e) { 
   /**
     * Funktionen für Cookies setzen, auslesen und löschen
     * Source: http://www.quirksmode.org/js/cookies.html#script

--- a/assets/js/overlay_showOnExit.js
+++ b/assets/js/overlay_showOnExit.js
@@ -6,7 +6,7 @@
  * @copyright Erdmann & Freunde
  */
 
-jQuery(document).ready(function($) {
+window.addEventListener("load", function(e) { 
   /**
     * Funktionen für Cookies setzen, auslesen und löschen
     * Source: http://www.quirksmode.org/js/cookies.html#script

--- a/assets/js/overlay_showOnPageLoad.js
+++ b/assets/js/overlay_showOnPageLoad.js
@@ -6,7 +6,7 @@
  * @copyright Erdmann & Freunde
  */
 
-jQuery(document).ready(function($) {
+window.addEventListener("load", function(e) { 
   /**
     * Funktionen für Cookies setzen, auslesen und löschen
     * Source: http://www.quirksmode.org/js/cookies.html#script


### PR DESCRIPTION
Use Vanilla JS instead of jQuery to detect page load, it's useful for people who don't use the Contao include (for x ou y reason). 

Thanks for your work ! (I might propose others PR to completely remove jQuery dependancy for your module :D)